### PR TITLE
Update to new URL for TMC26XStepper repo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
   https://github.com/ameyer/Arduino-L6470/archive/master.zip
-  https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
+  https://github.com/interactive-matter/TMC26XStepper/archive/master.zip
 
 #################################
 #                               #


### PR DESCRIPTION
When building the existing firmware, you get the error `Error: Got the unrecognized status code '404' when downloaded https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip`  
This repo has been removed, but `interactive-matter` seems to have a copy of it, so I just changed the location, seems to build OK